### PR TITLE
Adding missing package dependency and guard condition.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "request": "~2.53.0",
         "stream-to-array": "^2.0.2",
         "streamifier": "^0.1.1",
+        "temp": "^0.8.3",
         "twilio": "~1.6.0",
         "watson-developer-cloud": "^0.9.4",
         "when": "~3.x",

--- a/watson/s2t.js
+++ b/watson/s2t.js
@@ -62,7 +62,10 @@ module.exports = function (RED) {
             if (err) {
               console.log(err);
             } else {
-              msg.transcription = res.results[0].alternatives[0].transcript;
+              msg.transcription = '';
+              if (res.results.length && res.results[0].alternatives.length) {
+                msg.transcription = res.results[0].alternatives[0].transcript;
+              }
             }
 
             node.send(msg);


### PR DESCRIPTION
We were missing the 'temp' package and if the Watson service
returned no results we fell over. Added a guard condition to set
an empty transcription in this case.